### PR TITLE
FIX line description title using th instead of td

### DIFF
--- a/class/actions_shippableorder.class.php
+++ b/class/actions_shippableorder.class.php
@@ -43,7 +43,12 @@ class ActionsShippableorder
 
                 ?>
                 <script type="text/javascript">
-                    $('table#tablelines tr.liste_titre td.linecoldescription').first().after('<td class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></td><td class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></td>');
+                    var lineColDescription = $('table#tablelines tr.liste_titre th.linecoldescription');
+                    if (lineColDescription.length) {
+                        lineColDescription.first().after('<th class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></th><th class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></th>');
+                    } else {
+                        $('table#tablelines tr.liste_titre td.linecoldescription').first().after('<td class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></td><td class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></td>');
+                    }
 
                     <?php
                     foreach($object->lines as &$line) {


### PR DESCRIPTION
FIX line description title using th instead of td

Since PR 22646 in Dolibarr we use "th" tags instead of "td" tags in line title template.

![image](https://user-images.githubusercontent.com/45359511/215747296-3254b833-fe43-4ea1-88a5-1e767cf7fde0.png)