### PR TITLE
FIX line description title using th instead of td

### DIFF
--- a/class/actions_shippableorder.class.php
+++ b/class/actions_shippableorder.class.php
@@ -43,7 +43,12 @@ class ActionsShippableorder
 
                 ?>
                 <script type="text/javascript">
-                    $('table#tablelines tr.liste_titre td.linecoldescription').first().after('<td class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></td><td class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></td>');
+                    var lineColDescription = $('table#tablelines tr.liste_titre th.linecoldescription');
+                    if (lineColDescription.length) {
+                        lineColDescription.first().after('<th class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></th><th class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></th>');
+                    } else {
+                        $('table#tablelines tr.liste_titre td.linecoldescription').first().after('<td class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></td><td class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></td>');
+                    }
 
                     <?php
                     foreach($object->lines as &$line) {

--- a/class/actions_shippableorder.class.php
+++ b/class/actions_shippableorder.class.php
@@ -40,15 +40,24 @@ class ActionsShippableorder
                 $form = new Form($db);
                 $virtualTooltip = ShippableOrder::prepareTooltip();
             	$textColor = !empty($conf->global->THEME_ELDY_TEXTTITLE) ? $conf->global->THEME_ELDY_TEXTTITLE : '';
+                $jsConf = array(
+                    'textColor' => $textColor,
+                    'TheoreticalStockLabel' => $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip),
+                    'RealStock' => $langs->trans('RealStock')
+                );
 
                 ?>
                 <script type="text/javascript">
-                    var lineColDescription = $('table#tablelines tr.liste_titre th.linecoldescription');
-                    if (lineColDescription.length) {
-                        lineColDescription.first().after('<th class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></th><th class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></th>');
-                    } else {
-                        $('table#tablelines tr.liste_titre td.linecoldescription').first().after('<td class="linecolstock" align="right" style="color:<?php echo $textColor ?>;"><?php echo $form->textwithpicto($langs->trans('TheoreticalStock'), $virtualTooltip) ?></td><td class="linecolstock" align="right" style="<?php echo $textColor ?>;"><?php echo $langs->trans('RealStock') ?></td>');
+                    let jsConf = <?php echo  json_encode($jsConf); ?>;
+                    // From version 17 of Dolibarr and on other themes, the first column lines use a "th" tag instead of "td".
+                    // With the method below that allows to detect the "th" tag or the "td", we cover all versions and themes without fixing a version:
+                    let colTag = 'th';
+                    let lineColDescription = $('table#tablelines tr.liste_titre '+colTag+'.linecoldescription');
+                    if (lineColDescription.length == 0) {
+                        colTag = 'td';
+                        lineColDescription = $('table#tablelines tr.liste_titre '+colTag+'.linecoldescription');
                     }
+                    lineColDescription.first().after('<'+colTag+' class="linecolstock" align="right" style="color:'+jsConf.textColor+';">'+jsConf.TheoreticalStockLabel+'</'+colTag+'><'+colTag+' class="linecolstock" align="right" style="color:'+jsConf.textColor+';">'+jsConf.RealStock+'</'+colTag+'>');
 
                     <?php
                     foreach($object->lines as &$line) {


### PR DESCRIPTION
FIX line description title using th instead of td

Since PR 22646 in Dolibarr we use "th" tags instead of "td" tags in line title template.

![image](https://user-images.githubusercontent.com/45359511/215747296-3254b833-fe43-4ea1-88a5-1e767cf7fde0.png)